### PR TITLE
Add Slack notifications for SDK publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,3 +36,31 @@ jobs:
                   name: npm-debug-logs
                   path: /home/runner/.npm/_logs/
                   retention-days: 5
+
+            - name: Notify Slack - TypeScript SDK published
+              if: success()
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK_BUILD_WEBHOOK_URL }}
+              run: |
+                  VERSION=$(jq -r '.version' package.json)
+                  curl -s -X POST "$SLACK_WEBHOOK_URL" \
+                    -H 'Content-Type: application/json' \
+                    -d "{
+                      \"text\": \":white_check_mark: TypeScript SDK v${VERSION} published to npm\",
+                      \"blocks\": [{
+                        \"type\": \"section\",
+                        \"text\": {
+                          \"type\": \"mrkdwn\",
+                          \"text\": \":white_check_mark: *TypeScript SDK Published to npm*\n*Version:* \`${VERSION}\`\n*Package:* <https://www.npmjs.com/package/samsara-js-sdk/v/${VERSION}|samsara-js-sdk>\n*Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow>\"
+                        }
+                      }]
+                    }"
+
+            - name: Notify Slack on failure
+              if: failure()
+              env:
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SDK_BUILD_WEBHOOK_URL }}
+              run: |
+                  curl -s -X POST "$SLACK_WEBHOOK_URL" \
+                    -H 'Content-Type: application/json' \
+                    -d "{\"text\": \":x: TypeScript SDK publish to npm failed — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow>\"}"


### PR DESCRIPTION
Add Slack webhook notifications to `#alerts-api-sdk` for npm publish outcome:

- **`publish.yml`**: Success/failure notification when publishing to npm

Uses `SLACK_SDK_BUILD_WEBHOOK_URL` secret (Slack Incoming Webhook). Notifications use `curl -s` so Slack failures never block the workflow.

Part of a set of PRs adding notifications across all 5 SDK repos.

Made with [Cursor](https://cursor.com)